### PR TITLE
Speed up iTunes Search API search

### DIFF
--- a/.debendabot/config.yml
+++ b/.debendabot/config.yml
@@ -1,0 +1,11 @@
+# See: https://dependabot.com/docs/config-file/
+# See: https://dependabot.com/docs/config-file/validator/
+
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date as soon as new versions are published to the npm registry
+  - package_manager: "javascript"
+    directory: "/" # location of package.json
+    update_schedule: "live" # or "daily", "weekly", "monthly"
+    default_reviewers:
+      - "ooloth"

--- a/src/data/likes/albums.js
+++ b/src/data/likes/albums.js
@@ -179,7 +179,7 @@ exports.albums = [
   {
     name: `Sketches for My Sweetheart the Drunk`,
     id: 1476888879,
-    date: "May 26, 1998-05-26"
+    date: "1998-05-26"
   },
 
   // John Lennon

--- a/src/data/likes/albums.js
+++ b/src/data/likes/albums.js
@@ -224,7 +224,7 @@ exports.albums = [
   { name: `Coming Home`, id: 1079234232, date: "2015-06-23" },
 
   // Louis Prima
-  { name: `The Wildest!`, id: 725786218, date: "1957-01-01" },
+  { name: `The Wildest!`, id: 725786218, date: "1957" },
 
   // The Lumineers
   { name: `The Lumineers`, id: 1452839778, date: "2012-04-03" },
@@ -255,5 +255,5 @@ exports.albums = [
   },
 
   // Giuseppe Verdi
-  { name: `Messa da Requiem`, id: 1224287779, date: "1953-09-01" }
+  { name: `Messa da Requiem`, id: 1224287779, date: "1953-09" }
 ];

--- a/src/node/fetchiTunesData.js
+++ b/src/node/fetchiTunesData.js
@@ -1,83 +1,42 @@
 const fetch = require(`node-fetch`);
-const Bottleneck = require(`bottleneck`);
 
 const { albums } = require("../data/likes/albums");
 const { podcasts } = require("../data/likes/podcasts");
 const { books } = require("../data/likes/books");
 
-// See: https://stackoverflow.com/a/41377650/8802485
-// See: https://github.com/SGrondin/bottleneck#reservoir-intervals
-const limiter = new Bottleneck({
-  reservoir: 19, // max requests
-  reservoirRefreshAmount: 19,
-  reservoirRefreshInterval: 60 * 1000, // time span (must be divisible by 250)
-  maxConcurrent: 1,
-  minTime: 60000 / 19 // avg MS per request
-});
-
-// function getName(work) {
-//   return work.collectionName
-//     ? work.collectionName
-//         .replace(" (Expanded Edition)", "")
-//         .replace(" (Canadian Version)", "")
-//     : work.trackName
-//     ? work.trackName
-//     : null;
-// }
-
-function getLink(work) {
-  return work.collectionViewUrl
-    ? work.collectionViewUrl
-    : work.trackViewUrl
-    ? work.trackViewUrl
-    : null;
-}
-
 async function searchiTunesAPI(items) {
-  const itemsWithiTunesData = items.map(async item => {
-    async function fetchItemDetails() {
-      // See: https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/
-      return await fetch(
-        `https://itunes.apple.com/lookup?id=${item.id}&country=CA`
-      );
+  const stringOfItemIDs = items.map(item => item.id).join(",");
+
+  // See: https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/#lookup
+  const response = await fetch(
+    `https://itunes.apple.com/lookup?id=${stringOfItemIDs}&country=CA`
+  ).catch(error => console.log("searchiTunesAPI error", error));
+
+  const data = await response.json();
+
+  const formattedResults = data.results.map((result, i) => {
+    if (!result) {
+      console.log("No iTunes search result for:", result.name);
+      return null;
     }
 
-    try {
-      const response = await limiter.schedule(() => fetchItemDetails());
-      const data = await response.json();
+    const artist = result.artistName || items[i].artist || null;
+    const name = items[i].name;
+    const id = items[i].id;
+    const releaseDate = items[i].date;
+    const link = result.collectionViewUrl || result.trackViewUrl || null;
+    // See image srcset URLs used on books.apple.com:
+    const coverUrl = result.artworkUrl100.replace("100x100bb", "400x0w");
 
-      if (!data.results || !data.results[0]) {
-        console.log("No iTunes search results for:", item.name);
-        return null;
-      }
-
-      if (data.results.length > 1) {
-        console.log("More than one iTunes search result for:", item.name);
-        console.log("Results:", data.results);
-      }
-
-      const work = data.results[0];
-
-      const artist = work.artistName || item.artist || null; // podcasts don't need
-      const name = item.name;
-      const id = item.id;
-      const releaseDate = item.date;
-      const link = getLink(work);
-      // See image srcset URLs used on books.apple.com:
-      const coverUrl = work.artworkUrl100.replace("100x100bb", "400x0w");
-
-      if (!name || !id || !releaseDate || !link || !coverUrl) {
-        console.log(`Removed iTunes item:`, item);
-        return null;
-      }
-
-      return { artist, name, id, releaseDate, link, coverUrl };
-    } catch (error) {
-      console.log("searchiTunesAPI error", error);
+    if (!name || !id || !releaseDate || !link || !coverUrl) {
+      console.log(`Removed iTunes result:`, result);
+      return null;
     }
+
+    return { artist, name, id, releaseDate, link, coverUrl };
   });
 
-  return Promise.all(itemsWithiTunesData);
+  return formattedResults;
 }
 
 exports.fetchiTunesData = async () => {


### PR DESCRIPTION
Speed up Netlify builds (which are consistently timing out) by combining 100+ iTunes Search API queries (with extra time placed between each for rate limiting reasons) into a single, comma-delimited query for each media type.