### PR TITLE
Replace flawed YT ID regex with more reliable library solution

### DIFF
--- a/web/gatsby-config.ts
+++ b/web/gatsby-config.ts
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv'
+import getYouTubeID from 'get-youtube-id'
 
 dotenv.config()
 
@@ -64,12 +65,10 @@ export const siteMetadata = {
  * Custom YouTube link transformer for gatsby-remark-embedder
  */
 
-const getVideoId = (url: string): string => String(url.match(/\w+$/i))
-
 const getIframe = (url: string): string =>
   String(
     `<div class="my-8 ratio-16x9 rounded purple-gradient">
-      <iframe src="https://youtube.com/embed/${getVideoId(
+      <iframe src="https://youtube.com/embed/${getYouTubeID(
         url,
       )}" class="shadow-lg rounded" width="560" height="315" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
       </iframe>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13332,6 +13332,11 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
+    "get-youtube-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-youtube-id/-/get-youtube-id-1.0.1.tgz",
+      "integrity": "sha512-5yidLzoLXbtw82a/Wb7LrajkGn29BM6JuLWeHyNfzOGp1weGyW4+7eMz6cP23+etqj27VlOFtq8fFFDMLq/FXQ=="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "gatsby-transformer-remark": "^2.8.13",
     "gatsby-transformer-sharp": "^2.5.3",
     "gatsby-transformer-yaml": "^2.4.2",
+    "get-youtube-id": "^1.0.1",
     "postcss-import": "^12.0.1",
     "postcss-preset-env": "^6.7.0",
     "react": "^16.13.1",


### PR DESCRIPTION
Some YouTube embeds were broken because my custom regex wasn't capturing the full video ID when that ID included a `-` character. 